### PR TITLE
horoscope: update EMQ testing

### DIFF
--- a/cmd/card.go
+++ b/cmd/card.go
@@ -84,17 +84,19 @@ func testCard(*cli.Context) error {
 	return nil
 }
 
-func renderCardTable(coll map[string]map[string]*horoscope.Metrics) string {
+func renderCardTable(coll map[string]map[string]map[string]*horoscope.Metrics) string {
 	t := table.NewWriter()
-	t.AppendHeader(table.Row{"Table", "Column", "<= 2", "<= 3", "<= 4", "> 4", "max q-error"})
+	t.AppendHeader(table.Row{"Table", "Column", "Type", "<= 2", "<= 3", "<= 4", "<= 5", "<= 6", "<= 7", "<= 8", "<= 9", "<= 10", "> 10", "max q-error"})
 	for tableName, tbl := range coll {
-		for columnName, m := range tbl {
-			s := &stats.Sample{Xs: m.Values}
-			s.Sort()
-			c2, c3, c4 := countOf(s, 2), countOf(s, 3), countOf(s, 4)
+		for columnName, mt := range tbl {
+			for typeName, m := range mt {
+				s := &stats.Sample{Xs: m.Values}
+				s.Sort()
+				c2, c3, c4, c5, c6, c7, c8, c9, c10 := countOf(s, 2), countOf(s, 3), countOf(s, 4), countOf(s, 5), countOf(s, 6), countOf(s, 7), countOf(s, 8), countOf(s, 9), countOf(s, 10)
 
-			cb4, max := len(m.Values)-c4, s.Quantile(1)
-			t.AppendRow(table.Row{tableName, columnName, c2, c3 - c2, c4 - c3, cb4, max})
+				cb10, max := len(m.Values)-c10, s.Quantile(1)
+				t.AppendRow(table.Row{tableName, columnName, typeName, c2, c3 - c2, c4 - c3, c5 - c4, c6 - c5, c7 - c6, c8 - c7, c9 - c8, c10 - c9, cb10, max})
+			}
 		}
 	}
 	return t.Render()

--- a/pkg/horoscope/card.go
+++ b/pkg/horoscope/card.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -19,6 +20,8 @@ const (
 	TypeEMQ CardinalityQueryType = "emq"
 	TypeRGE CardinalityQueryType = "rge"
 	TypeDCT CardinalityQueryType = "dct"
+
+	defaultConcurrency = 30
 )
 
 type Cardinalitor struct {
@@ -37,9 +40,9 @@ func NewCardinalitor(exec executor.Executor, tableColumns map[string][]string, t
 	}
 }
 
-func (c *Cardinalitor) Test() (map[string]map[string]*Metrics, error) {
-	result := make(map[string]map[string]*Metrics)
-	var fun func(ctx context.Context, tableName, columnName string) (*Metrics, error)
+func (c *Cardinalitor) Test() (map[string]map[string]map[string]*Metrics, error) {
+	result := make(map[string]map[string]map[string]*Metrics)
+	var fun func(ctx context.Context, tableName, columnName string) (map[string]*Metrics, error)
 	switch c.Type {
 	case TypeEMQ:
 		fun = c.testEMQ
@@ -56,7 +59,7 @@ func (c *Cardinalitor) Test() (map[string]map[string]*Metrics, error) {
 	}
 	for tableName, columns := range c.TableColumns {
 		if _, e := result[tableName]; !e {
-			result[tableName] = make(map[string]*Metrics)
+			result[tableName] = make(map[string]map[string]*Metrics)
 		}
 		tableMap := result[tableName]
 		for _, columnName := range columns {
@@ -67,10 +70,10 @@ func (c *Cardinalitor) Test() (map[string]map[string]*Metrics, error) {
 			log.WithFields(log.Fields{
 				"table":        tableName,
 				"column":       columnName,
-				"q-error 50th": m.quantile(0.50),
-				"q-error 90th": m.quantile(0.90),
-				"q-error 95th": m.quantile(0.95),
-				"q-error max":  m.quantile(1),
+				"q-error 50th": m["all"].quantile(0.50),
+				"q-error 90th": m["all"].quantile(0.90),
+				"q-error 95th": m["all"].quantile(0.95),
+				"q-error max":  m["all"].quantile(1),
 			}).Infof("q-error for %s.%s", tableName, columnName)
 			tableMap[columnName] = m
 		}
@@ -78,59 +81,96 @@ func (c *Cardinalitor) Test() (map[string]map[string]*Metrics, error) {
 	return result, nil
 }
 
-func (c *Cardinalitor) testEMQ(ctx context.Context, tableName, columnName string) (metrics *Metrics, err error) {
-	const batchSize = 1000
-	metrics = &Metrics{}
-	rows, err := c.exec.Query(fmt.Sprintf("SELECT COUNT(DISTINCT %s) FROM %s", columnName, tableName))
-	if err != nil {
-		return nil, fmt.Errorf("fetch count(distinct %s) from %s occurred an error: %v", columnName, tableName, err)
-	}
-	count, err := strconv.ParseInt(string(rows.Data[0][0]), 10, 64)
-	if err != nil {
-		return nil, err
-	}
-	for i := 0; i*batchSize < int(count); i++ {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-		}
-		rows, err := c.exec.Query(fmt.Sprintf("SELECT DISTINCT %s FROM %s ORDER BY %s LIMIT %d, %d",
-			columnName, tableName, columnName, i*batchSize, batchSize,
-		))
-		if err != nil {
-			return nil, err
-		}
-		for _, row := range rows.Data {
-			value, op := row[0], "IS"
-			stringValue, bareValue := "NULL", "NULL"
-			if value != nil {
-				bareValue, op = strings.Replace(string(value), "'", "\\'", -1), "="
-				stringValue = fmt.Sprintf("'%s'", bareValue)
-			}
-			rows, _, err := c.exec.ExplainAnalyze(fmt.Sprintf("SELECT %s FROM %s WHERE %s %s %s", columnName, tableName, columnName, op, stringValue))
-			if err != nil {
-				return nil, err
-			}
-			cis := executor.CollectEstAndActRows(executor.NewExplainAnalyzeInfo(rows))
-			qError := cis[0].QError
-			if qError != math.Inf(1) {
-				metrics.Values = append(metrics.Values, qError)
-			}
+func (c *Cardinalitor) testEMQ(ctx context.Context, tableName, columnName string) (metrics map[string]*Metrics, err error) {
+	var mLock sync.Mutex
+	metrics = make(map[string]*Metrics)
+	metrics["all"] = &Metrics{}
+	metrics["most_common_10%"] = &Metrics{}
+	metrics["least_common_10%"] = &Metrics{}
 
-			log.WithFields(log.Fields{
-				"table":   tableName,
-				"column":  columnName,
-				"value":   bareValue,
-				"q-error": qError,
-			}).Info("q-error result")
-		}
+	rows, err := c.exec.Query(fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName))
+	if err != nil {
+		return nil, fmt.Errorf("fetch total count error: %v", err)
 	}
-	return metrics, nil
+	tot, err := strconv.Atoi(string(rows.Data[0][0]))
+	if err != nil {
+		return nil, fmt.Errorf("fetch total count error: %v", err)
+	}
+
+	p10 := tot / 10
+	rows, err = c.exec.Query(fmt.Sprintf("SELECT %s FROM %s GROUP BY %s ORDER BY COUNT(*) DESC LIMIT %v", columnName, tableName, columnName, p10))
+	if err != nil {
+		return nil, fmt.Errorf("fetch most common values error: %v", err)
+	}
+	mcvs := make(map[string]struct{})
+	for _, d := range rows.Data {
+		mcvs[string(d[0][0])] = struct{}{}
+	}
+	rows, err = c.exec.Query(fmt.Sprintf("SELECT %s FROM %s GROUP BY %s ORDER BY COUNT(*) LIMIT %v", columnName, tableName, columnName, p10))
+	if err != nil {
+		return nil, fmt.Errorf("fetch most common values error: %v", err)
+	}
+	lcvs := make(map[string]struct{})
+	for _, d := range rows.Data {
+		lcvs[string(d[0][0])] = struct{}{}
+	}
+
+	rowCh := make(chan executor.Row, defaultConcurrency)
+	var wg sync.WaitGroup
+	for i := 0; i < defaultConcurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for true {
+				row, ok := <-rowCh
+				if !ok {
+					return
+				}
+				value, op := row[0], "IS"
+				stringValue, bareValue := "NULL", "NULL"
+				if value != nil {
+					bareValue, op = strings.Replace(string(value), "'", "\\'", -1), "="
+					stringValue = fmt.Sprintf("'%s'", bareValue)
+				}
+				rows, _, err := c.exec.ExplainAnalyze(fmt.Sprintf("SELECT %s FROM %s WHERE %s %s %s", columnName, tableName, columnName, op, stringValue))
+				if err != nil {
+					log.Fatalln(err)
+					return
+				}
+				cis := executor.CollectEstAndActRows(executor.NewExplainAnalyzeInfo(rows))
+				qError := cis[0].QError
+				if qError != math.Inf(1) {
+					mLock.Lock()
+					metrics["all"].Values = append(metrics["all"].Values, qError)
+					if _, ok := mcvs[string(value)]; ok {
+						metrics["most_common_10%"].Values = append(metrics["most_common_10%"].Values, qError)
+					}
+					if _, ok := lcvs[string(value)]; ok {
+						metrics["least_common_10%"].Values = append(metrics["least_common_10%"].Values, qError)
+					}
+					mLock.Unlock()
+				}
+
+				log.WithFields(log.Fields{
+					"table":   tableName,
+					"column":  columnName,
+					"value":   bareValue,
+					"q-error": qError,
+				}).Info("q-error result")
+			}
+		}()
+	}
+	for _, row := range rows.Data {
+		rowCh <- row
+	}
+	close(rowCh)
+	wg.Wait()
+	return metrics, err
 }
 
-func (c *Cardinalitor) testREG(ctx context.Context, tableName, columnName string) (metrics *Metrics, err error) {
-	metrics = &Metrics{}
+func (c *Cardinalitor) testREG(ctx context.Context, tableName, columnName string) (metrics map[string]*Metrics, err error) {
+	metrics = make(map[string]*Metrics)
+	metrics["all"] = &Metrics{}
 	rows, err := c.exec.Query(fmt.Sprintf("SELECT COUNT(DISTINCT %s) FROM %s WHERE %s IS NOT NULL", columnName, tableName, columnName))
 	if err != nil {
 		return nil, fmt.Errorf("fetch count(distinct %s) from %s occurred an error: %v", columnName, tableName, err)
@@ -176,7 +216,7 @@ func (c *Cardinalitor) testREG(ctx context.Context, tableName, columnName string
 			cis := executor.CollectEstAndActRows(executor.NewExplainAnalyzeInfo(rows))
 			qError := cis[0].QError
 			if qError != math.Inf(1) {
-				metrics.Values = append(metrics.Values, qError)
+				metrics["all"].Values = append(metrics["all"].Values, qError)
 			}
 			log.WithFields(log.Fields{
 				"table":   tableName,


### PR DESCRIPTION
1. Speed EMQ testing up by parallelizing it and removing the heavy SQL `SELECT DISTINCT %s FROM %s ORDER BY %s LIMIT %d, %d`;
2. Output more information in EMQ testing, after this PR, it also prints q-errors about most/least common values:
```
+-------+--------+------------------+------+------+------+------+------+------+------+------+-------+------+-------------+
| TABLE | COLUMN | TYPE             | <= 2 | <= 3 | <= 4 | <= 5 | <= 6 | <= 7 | <= 8 | <= 9 | <= 10 | > 10 | MAX Q-ERROR |
+-------+--------+------------------+------+------+------+------+------+------+------+------+-------+------+-------------+
| t     | a      | all              |  100 |    0 |    0 |    0 |    0 |    0 |    0 |    0 |     0 |    0 |      1.9412 |
| t     | a      | most_common_10%  |   10 |    0 |    0 |    0 |    0 |    0 |    0 |    0 |     0 |    0 |      1.9412 |
| t     | a      | least_common_10% |   10 |    0 |    0 |    0 |    0 |    0 |    0 |    0 |     0 |    0 |      1.9412 |
+-------+--------+------------------+------+------+------+------+------+------+------+------+-------+------+-------------+
```